### PR TITLE
Fix manual release deploy: build VSIX from selected tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,19 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/checkout@v4
 
+      - name: Checkout code (release tag)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.release_tag }}
+
       - name: Setup Node.js
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: npm ci
 
       - name: Detect publishing secrets
@@ -74,27 +78,15 @@ jobs:
           fi
 
       - name: Run tests (includes lint/build)
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: npm test
 
       - name: Install packaging tool
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: npm install -g @vscode/vsce
 
       - name: Package extension
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           vsce package
-
-      - name: Download VSIX from GitHub Release
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          RELEASE_TAG="$(jq -r '.inputs.release_tag' "$GITHUB_EVENT_PATH")"
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "*.vsix"
 
       - name: Validate VSIX
         run: |


### PR DESCRIPTION
Fix workflow_dispatch failure when the selected release has no VSIX asset attached.

- On manual deploy, checkout github.event.inputs.release_tag and build/package the VSIX instead of downloading release assets.
- Publish jobs remain split (VS Code Marketplace / Open VSX) and are controlled by workflow_dispatch inputs.

Repro: Actions run 20327586086 failed with "no assets to download".